### PR TITLE
Upgrade Markdown parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     rdoc (4.2.2)
       json (~> 1.4)
     redcarpet (3.3.4)
-    rouge (1.10.1)
+    rouge (2.0.0)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -278,4 +278,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/lib/red_carpet_code_highlighter.rb
+++ b/lib/red_carpet_code_highlighter.rb
@@ -4,4 +4,8 @@ require 'rouge/plugins/redcarpet'
 
 class RedCarpetCodeHighlighter < Redcarpet::Render::HTML
   include Rouge::Plugins::Redcarpet
+
+  def initialize(extensions = {})
+    super extensions.merge(link_attributes: { target: "_blank" })
+  end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownHelper, type: :helper do
+  describe '#markdown' do
+    before { include described_class }
+
+    describe '#render' do
+      subject { markdown.render(text) }
+
+      context 'with links' do
+        let(:text) { '[My link](http://link.com)' }
+
+        it 'parses links' do
+          is_expected.to include('<a href="http://link.com" target="_blank">My link</a>')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change:
- Upgrades `rouge`
- Causes markdown links to be opened in a new tab